### PR TITLE
feat(ui): improve MediaControl styling and add placeholder

### DIFF
--- a/src/edit/MediaControl.tsx
+++ b/src/edit/MediaControl.tsx
@@ -66,7 +66,7 @@ const MediaControl = ( { onSelect, onRemove, media }: MediaControlProps ) => {
 					<Button
 						className={
 							media?.url
-								? 'flex justify-center overflow-hidden p-0 w-full h-auto'
+								? 'flex justify-center overflow-hidden p-0 w-full !h-auto'
 								: 'rounded-tl min-h-[90px] px-2 text-center bg-[#f0f0f0] justify-center w-full'
 						}
 						onClick={ open }
@@ -78,10 +78,13 @@ const MediaControl = ( { onSelect, onRemove, media }: MediaControlProps ) => {
 						{ isLoading && <Spinner /> }
 					</Button>
 					{ media?.url ? (
-						<Flex className="absolute transition-opacity duration-[50ms] ease-[ease-out] p-2 bottom-0 opacity-0 hover:opacity-100">
+						<Flex
+							align="flex-end"
+							className="absolute transition-opacity duration-[50ms] ease-[ease-out] p-2 bottom-0 opacity-0 hover:opacity-100 h-full"
+						>
 							<FlexBlock>
 								<Button
-									className="backdrop-blur-lg backdrop-saturate-[180%] grow justify-center bg-[hsla(0,0%,100%,.75)] w-full"
+									className="backdrop-blur-lg backdrop-saturate-[180%] grow justify-center !bg-[hsla(0,0%,100%,.75)] w-full"
 									onClick={ open }
 									aria-hidden="true"
 								>
@@ -92,7 +95,7 @@ const MediaControl = ( { onSelect, onRemove, media }: MediaControlProps ) => {
 							</FlexBlock>
 							<FlexBlock>
 								<Button
-									className="backdrop-blur-lg backdrop-saturate-[180%] grow justify-center bg-[hsla(0,0%,100%,.75)] w-full"
+									className="backdrop-blur-lg backdrop-saturate-[180%] grow justify-center !bg-[hsla(0,0%,100%,.75)] w-full"
 									onClick={ onRemove }
 								>
 									{ __( 'Remove' ) }

--- a/src/edit/MediaControl.tsx
+++ b/src/edit/MediaControl.tsx
@@ -80,13 +80,12 @@ const MediaControl = ( { onSelect, onRemove, media }: MediaControlProps ) => {
 					{ media?.url ? (
 						<Flex
 							align="flex-end"
-							className="absolute transition-opacity duration-[50ms] ease-[ease-out] p-2 bottom-0 opacity-0 hover:opacity-100 h-full"
+							className="absolute inset-0 p-2 h-full transition-opacity duration-[50ms] ease-[ease-out] opacity-0 hover:opacity-100 focus-within:opacity-100"
 						>
 							<FlexBlock>
 								<Button
 									className="backdrop-blur-lg backdrop-saturate-[180%] grow justify-center !bg-[hsla(0,0%,100%,.75)] w-full"
 									onClick={ open }
-									aria-hidden="true"
 								>
 									{ !! media?.url
 										? __( 'Replace' )

--- a/src/edit/index.tsx
+++ b/src/edit/index.tsx
@@ -3,8 +3,14 @@
  */
 import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import type { BlockEditProps } from '@wordpress/blocks';
-import { PanelBody, RangeControl, ToggleControl } from '@wordpress/components';
+import {
+	PanelBody,
+	Placeholder,
+	RangeControl,
+	ToggleControl,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { gallery } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -63,7 +69,21 @@ export default function Edit( props: EditProps ): JSX.Element {
 					/>
 				</PanelBody>
 			</InspectorControls>
-			<Images images={ images } />
+			{ images.length > 0 ? (
+				<Images images={ images } />
+			) : (
+				<Placeholder
+					icon={ gallery }
+					label={ __(
+						'Carousel Gallery Block',
+						'carousel-gallery-block'
+					) }
+					instructions={ __(
+						'Add images to your carousel gallery',
+						'carousel-gallery-block'
+					) }
+				/>
+			) }
 		</div>
 	);
 }


### PR DESCRIPTION
## Summary
- Improve MediaControl component styling
- Add placeholder when no images are present
- Enhance usability and accessibility

## Changes
### MediaControl.tsx
- Use `!important` in button styles for CSS specificity control
- Set Flex container `align-items` to `flex-end` for better layout
- Improve hover overlay display

### edit/index.tsx  
- Display `Placeholder` component when no images are present
- Provide user guidance with gallery icon and instructions

## Test plan
- [ ] Add block in block editor
- [ ] Verify placeholder displays when no images are present
- [ ] Add images and confirm MediaControl works properly
- [ ] Verify hover styles are applied correctly

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新機能
  - 画像がない場合にプレースホルダーを表示。ギャラリーアイコン、翻訳対応のラベル「Carousel Gallery Block」とガイダンス「カルーセルギャラリーに画像を追加」を追加。

- スタイル
  - メディア上のオーバーレイを全高化しアクションを下部に揃えて表示安定性を向上（フォーカスで常に表示）。
  - 置換／削除ボタンの背景コントラストを強化し視認性を改善。
  - プライマリーボタンの高さを安定化し表示崩れを軽減。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->